### PR TITLE
feature/NSA-2339/password-reset-for-invitations

### DIFF
--- a/config/login.dfe.interactions.dev.json
+++ b/config/login.dfe.interactions.dev.json
@@ -11,6 +11,7 @@
   },
   "hostingEnvironment": {
     "portalUrl": "https://login-dfe-portal.herokuapp.com",
+    "profileUrl": "https://profile.dfe.signin.docker:8015",
     "env": "dev",
     "host": "localhost",
     "port": 4431,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "test": "./node_modules/.bin/jest",
+    "test": "./node_modules/.bin/jest --coverage",
+    "test-watcher": "./node_modules/.bin/jest --watch --coverage",
     "dev": "settings='./config/login.dfe.interactions.dev.json' node src/index.js"
   },
   "repository": {

--- a/src/app/ResetPassword/postRequestPasswordReset.js
+++ b/src/app/ResetPassword/postRequestPasswordReset.js
@@ -63,6 +63,7 @@ const action = async (req, res) => {
         logger.info(`Found an invitation for ${email}. Resending invitation...`);
         await users.resendInvitation(invitation.id, req.id);
         res.redirect(`${config.hostingEnvironment.profileUrl}/register/${invitation.id}?clientid=${req.body.clientId}&redirect_uri=${req.body.redirectUri}`);
+        return;
       }     
     }
     res.redirect(`/${req.params.uuid}/resetpassword/${uuid()}/confirm?clientid=${req.body.clientId}&redirect_uri=${req.body.redirectUri}`);

--- a/src/app/ResetPassword/postRequestPasswordReset.js
+++ b/src/app/ResetPassword/postRequestPasswordReset.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const config = require('./../../infrastructure/Config')();
 const emailValidator = require('email-validator');
 const users = require('./../../infrastructure/Users');
 const userCodes = require('./../../infrastructure/UserCodes');
@@ -57,11 +58,11 @@ const action = async (req, res) => {
     }
     else {
       logger.warn(`Could not find an active user for ${email}. Checking invitations...`);
-      const invitation = await users.findInvitationByEmail(email, correlationId);
+      const invitation = await users.findInvitationByEmail(email, req.id);
       if (invitation && !invitation.isCompleted && !invitation.deactivated) {
         logger.info(`Found an invitation for ${email}. Resending invitation...`);
-        await users.resendInvitation(invitation.id, correlationId);
-        res.redirect(`/${req.params.uuid}/resetpassword/${uuid()}/checkEmail?clientid=${req.body.clientId}&redirect_uri=${req.body.redirectUri}`);
+        await users.resendInvitation(invitation.id, req.id);
+        res.redirect(`${config.hostingEnvironment.profileUrl}/register/${invitation.id}?clientid=${req.body.clientId}&redirect_uri=${req.body.redirectUri}`);
       }     
     }
     res.redirect(`/${req.params.uuid}/resetpassword/${uuid()}/confirm?clientid=${req.body.clientId}&redirect_uri=${req.body.redirectUri}`);

--- a/src/infrastructure/Users/DirectoriesApiUserAdapter.js
+++ b/src/infrastructure/Users/DirectoriesApiUserAdapter.js
@@ -270,6 +270,30 @@ const acceptInvitation = async (invitationId, password, correlationId) => {
   }
 };
 
+const resendInvitation = async (invitationId, correlationId) => {
+  const token = await jwtStrategy(config.directories.service).getBearerToken();
+
+  try {
+    const result = await rp({
+      method: 'POST',
+      uri: `${config.directories.service.url}/invitations/${invitationId}/resend`,
+      headers: {
+        authorization: `bearer ${token}`,
+        'x-correlation-id': correlationId,
+      },
+      json: true,
+    });
+
+    return result;
+  } catch (e) {
+    const status = e.statusCode ? e.statusCode : 500;
+    if (status === 404) {
+      return null;
+    }
+    throw new Error(e);
+  }
+};
+
 module.exports = {
   authenticate,
   find,
@@ -280,4 +304,5 @@ module.exports = {
   update,
   findInvitationByEmail,
   acceptInvitation,
+  resendInvitation,
 };


### PR DESCRIPTION
Allows users who haven't activated their invites to use the forgotten password flow.
- Checks that the user doesn't already exists
- Checks the list of invitations
- Resend the invitation if found
- Redirects the user to the account setup / password flow
