### PR TITLE
bugfix: force the config file to never be null for local test runs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/dfe-ssp/_packaging/Signin-Default/npm/registry/ 
+                        
+always-auth=true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "12.x.x"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jest --coverage",
+    "test": "settings=./config/login.dfe.interactions.dev.json jest --coverage",
     "test-watcher": "./node_modules/.bin/jest --watch --coverage",
     "dev": "node src/index.js",
     "link-config": "npm link login.dfe.config"


### PR DESCRIPTION
Bringing in linkable-configs had a blind-spot. If you haven't linked the configuration it will attempt to run the tests and fail locally.

This forces the settings to be non-null.